### PR TITLE
doris binlog同步bugfix

### DIFF
--- a/flinkx-connectors/flinkx-connector-doris/src/main/java/com/dtstack/flinkx/connector/doris/rest/DorisLoadClient.java
+++ b/flinkx-connectors/flinkx-connector-doris/src/main/java/com/dtstack/flinkx/connector/doris/rest/DorisLoadClient.java
@@ -269,9 +269,8 @@ public class DorisLoadClient implements Serializable {
                     if (headers[i].startsWith(KEY_BEFORE)) {
                         String trueCol = headers[i].substring(7);
                         if (column.equalsIgnoreCase(trueCol)) {
-                            insertV.add(convert(value, i));
                             deleteV.add(convert(value, i));
-                            break;
+                            continue;
                         }
                     }
                     // case 2, need to insert.
@@ -279,7 +278,7 @@ public class DorisLoadClient implements Serializable {
                         String trueCol = headers[i].substring(6);
                         if (column.equalsIgnoreCase(trueCol)) {
                             insertV.add(convert(value, i));
-                            break;
+                            continue;
                         }
                     }
                     // case 3. column name is obvious.
@@ -288,7 +287,7 @@ public class DorisLoadClient implements Serializable {
                         if (delete) {
                             deleteV.add(convert(value, i));
                         }
-                        break;
+                        continue;
                     }
                 }
             }


### PR DESCRIPTION
flinkx在binlog开启时候，不会全量同步已有数据和增量同步到doris 主要是DorisLoadClient.java中，insert拼接值得逻辑拼接原有的值